### PR TITLE
Quote PHP executable path

### DIFF
--- a/src/QueueHandler.php
+++ b/src/QueueHandler.php
@@ -56,7 +56,7 @@ class QueueHandler
         }
 
         $cmd = array_merge(
-            [$php],
+            ['"' . $php . '"'],
             $executableFinder->findArguments(),
             ['craft', 'queue/run -v']
         );


### PR DESCRIPTION
If you're a complete loony like me and have PHP's binary in a path including a space (`C:\Program Files\php7`), the current version throws a fun error about `C:\Program` not existing.

Just added quotes around it to catch that.