### PR TITLE
Adding Testing Code for the Issue #11

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,6 +15,7 @@ use craft\base\Plugin as BasePlugin;
 use craft\queue\BaseJob;
 use craft\queue\Command;
 use craft\queue\Queue;
+use yii\base\Controller;
 use yii\base\ActionEvent;
 use yii\base\Event;
 use yii\caching\CacheInterface;
@@ -74,6 +75,18 @@ class Plugin extends BasePlugin
             Command::EVENT_AFTER_ACTION,
             function (ActionEvent $event) {
                 if ('run' === $event->action->id) {
+                    file_put_contents('/var/www/app/storage/logs/async-queue.log', "COMMAND::EVENT_AFTER_ACTION TRIGGERED!!!\n", FILE_APPEND);
+                    $this->getPool()->decrement();
+                }
+            }
+        );
+
+        Event::on(
+            Controller::class,
+            Controller::EVENT_AFTER_ACTION,
+            function (ActionEvent $event) {
+                if ('run' === $event->action->id) {
+                    file_put_contents('/var/www/app/storage/logs/async-queue.log', "CONTROLLER::EVENT_AFTER_ACTION TRIGGERED!!!\n", FILE_APPEND);
                     $this->getPool()->decrement();
                 }
             }

--- a/src/ProcessPool.php
+++ b/src/ProcessPool.php
@@ -39,7 +39,7 @@ class ProcessPool
      */
     public function __construct(Settings $settings, CacheInterface $cache)
     {
-        $this->maxItems = $settings->concurrency;
+        $this->maxItems = 500; //$settings->concurrency; hardcoding for test
         $this->lifetime = $settings->poolLifetime;
         $this->cache    = $cache;
     }
@@ -52,7 +52,7 @@ class ProcessPool
     public function canIUse()
     {
         $poolUsage = $this->cache->get(self::CACHE_KEY) ?: 0;
-
+        file_put_contents('/var/www/app/storage/logs/async-queue.log', "In use {$this->cache->get(self::CACHE_KEY)}\n", FILE_APPEND);
         return ($poolUsage < $this->maxItems) ? true : false;
 
     }

--- a/src/QueueHandler.php
+++ b/src/QueueHandler.php
@@ -22,7 +22,7 @@ class QueueHandler
     {
         $cmd = $this->getCommand();
         $cwd = CRAFT_BASE_PATH;
-
+        file_put_contents('/var/www/app/storage/logs/async-queue.log', $cmd . "\n", FILE_APPEND);
         $process = new Process($cmd, $cwd);
 
         try {


### PR DESCRIPTION
**DO NOT MERGE**
This is just for testing purpose.
Refer to https://github.com/ostark/craft-async-queue/issues/11

A fast but not good fix will be delete the cache when the whole item in the queue finished.

ProcessPool.php:72
```PHP
public function decrement() {
        $this->cache->delete(self::CACHE_KEY);
}
```

To see the output of any queue task:
```BASH
touch storage/logs/async-queue.log
chown www-data:www-data storage/logs/async-queue.log
tail -f storage/logs/async-queue.log

In use
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 1
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 2
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 3
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
CONTROLLER::EVENT_AFTER_ACTION TRIGGERED!!!
In use
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 1
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 2
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 3
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
CONTROLLER::EVENT_AFTER_ACTION TRIGGERED!!!
In use
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 1
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 2
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 3
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 4
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 5
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 6
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
In use 7
nice /usr/bin/php craft queue/run -v > /dev/null 2>&1 &
CONTROLLER::EVENT_AFTER_ACTION TRIGGERED!!!
```