### PR TITLE
Craft 3 backport with defensive rate limiting

### DIFF
--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -44,7 +44,8 @@ class RateLimiter
             $this->queue->channel = 'queue';
             $reserved = $this->queue->getTotalReserved();
         } catch (\Exception) {
-            $reserved = 0;
+            $this->increment();
+            return false;
         }
 
         $currentUsage = $this->internalCount + $reserved;

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -70,4 +70,23 @@ class RateLimiterTest extends TestCase
 
         $this->assertSame(0, $this->plugin->getRateLimiter()->getInternalCount());
     }
+
+
+    public function test_stop_spawning_processes_when_counting_jobs_failed(): void
+    {
+        // Fake the reserved count
+        $queue = new class extends \craft\queue\Queue {
+            public function getTotalReserved(): int
+            {
+                throw new \Exception('Unable to count jobs');
+            }
+        };
+
+        $this->plugin->set('async_rate_limiter', new \ostark\AsyncQueue\RateLimiter($queue, $this->plugin->getSettings()));
+        $handler = new \ostark\AsyncQueue\Handlers\BackgroundQueueHandler($this->plugin);
+
+        $handler->__invoke(new PushEvent());
+
+        $this->assertFalse($this->plugin->getRateLimiter()->canIUse());
+    }
 }


### PR DESCRIPTION
 Stop spawning new processes if counting queue jobs failed.