### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^8.0",
     "craftcms/cms": "^4.0.0",
-    "symfony/process": "^5.0"
+    "symfony/process": "^5.0|^6.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Any chance we can open up the version constraint here? We've got some old projects using this plugin and it's preventing upgrades since some newer things require 6 but this is pinned to 5.