### PR TITLE
README.md -> Craft 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package is [Treeware](https://treeware.earth). If you use it in production,
 
 ## Requirements
 
-* Craft 3 or 4
+* Craft 3, 4, 5
 * Permissions to execute a php binary
 * proc_open()
 * **PHP >=7.1** (for PHP 7.0 use `ostark/craft-async-queue:1.3.*`)


### PR DESCRIPTION
Mention that this version also supports Craft 5.

## Further ideas

* Remove PHP 7 examples from README (looks dated) maybe stop supporting PHP 7?
* Change the about section in GH settings, currently says: 'Async Queue Handler for Craft 3 and 4'
* Change wording about 'free time' with sponsorship - a link to fortrabbit is still welcome :)