### PR TITLE
Removed PHP requirement as it is already included in craftcms/cms

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     }
   ],
   "require": {
-    "php": "^8.0",
     "craftcms/cms": "^5.0",
     "symfony/process": "^5.0|^6.0"
   },


### PR DESCRIPTION
The PHP requirement conflicted for installations on platform with PHP8.2 installed.

Please also update version tag to 5.0.0 to be compatible with gross packages linked to craft and the main version it should be compatible with.